### PR TITLE
Optimize memcpy

### DIFF
--- a/libs/libc/include/string.h
+++ b/libs/libc/include/string.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2020-2021 Nikita Melekhin. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ *
+ * Modified by: bellrise
+ */
 #ifndef _LIBC_STRING_H
 #define _LIBC_STRING_H
 
@@ -7,15 +15,37 @@
 
 __BEGIN_DECLS
 
-void* memset(void* dest, int fll, size_t nbytes);
-void* memmove(void* dest, const void* src, size_t nbytes);
-void* memcpy(void* dest, const void* src, size_t nbytes);
-void* memccpy(void* dest, const void* src, int stop, size_t nbytes);
+/* Set 'nbytes' to 'fill' starting from 'dest'. */
+void* memset(void* dest, int fill, size_t nbytes);
+
+/* Move 'nbytes' from 'src' to 'dest' */
+void* memmove(void* dest, const void* __restrict src, size_t nbytes);
+
+/* Copy 'nbytes' from 'src' to 'dest'. See the comment in the source file
+   about optimization and restricting pointers. */
+void* memcpy(void* __restrict dest, const void* __restrict src, size_t nbytes);
+
+/* Copy 'nbytes' from 'src' to 'dest', stopping if the current byte matches
+   'stop'. Note that the stop byte also gets copied over. */
+void* memccpy(void* dest, const void* __restrict src, int stop, size_t nbytes);
+
+/* Compare 'nbytes' from 'src1' and 'src2'. Return 0 if all the bytes match,
+   otherwise return the difference. */
 int memcmp(const void* src1, const void* src2, size_t nbytes);
 
-size_t strlen(const char* s);
+/* Calculate the string length starting from 'str'. */
+size_t strlen(const char* str);
+
+/* Copy 'src' into 'dest' until it finds a null byte in the source string.
+   Note that this is dangerous because it writes memory no matter the size
+   the 'dest' buffer is. */
 char* strcpy(char* dest, const char* src);
-char* strncpy(char* dest, const char* src, size_t n);
+
+/* Copy 'src' into 'dest' until it finds a null byte or reaches the 'nbytes'
+   limit provided by the user. This is the recommended way of copying strings,
+   instead of using regular strcpy. Note that this will fill the 'dest' buffer
+   with null bytes if the amount of copied bytes is lower than 'nbytes'. */
+char* strncpy(char* dest, const char* src, size_t nbytes);
 
 __END_DECLS
 

--- a/libs/libc/string/string.c
+++ b/libs/libc/string/string.c
@@ -85,11 +85,9 @@ int memcmp(const void* src1, const void* src2, size_t nbytes)
         first = (uint8_t*)src1 + i;
         second = (uint8_t*)src2 + i;
 
-        if (*first < *second)
-            return first - second;
-
-        if (*first > *second)
-            return first - second;
+        /* Return the difference if the byte does not match. */
+        if (*first != *second)
+            return *first - *second;
     }
 
     return 0;

--- a/libs/libc/string/string.c
+++ b/libs/libc/string/string.c
@@ -11,9 +11,9 @@
 #ifdef __i386__
 void* memset(void* dest, int fill, size_t nbytes)
 {
-    for (int i = 0; i < nbytes; ++i) {
+    for (int i = 0; i < nbytes; ++i)
         ((uint8_t*)dest)[i] = fill;
-    }
+
     return dest;
 }
 #endif //__i386__
@@ -21,12 +21,13 @@ void* memset(void* dest, int fill, size_t nbytes)
 void* memmove(void* dest, const void* src, size_t nbytes)
 {
     if (src > dest) {
-        for (int i = 0; i < nbytes; ++i)
-            ((uint8_t*)dest)[i] = ((uint8_t*)src)[i];
-    } else {
-        for (int i = nbytes - 1; i >= 0; --i)
-            ((uint8_t*)dest)[i] = ((uint8_t*)src)[i];
+        memcpy(dest, src, nbytes);
+        return dest;
     }
+
+    for (int i = nbytes - 1; i >= 0; --i)
+        ((uint8_t*)dest)[i] = ((uint8_t*)src)[i];
+
     return dest;
 }
 
@@ -51,7 +52,7 @@ void* memcpy(void* __restrict dest, const void* __restrict src, size_t nbytes)
         goto skip_chunks;
 
     for (i = 0; i < chunks; i++)
-        ((uint32_t *) dest)[i] = ((uint32_t*)src)[i];
+        ((uint32_t*)dest)[i] = ((uint32_t*)src)[i];
 
 skip_chunks:
 
@@ -67,25 +68,30 @@ skip_chunks:
 
 void* memccpy(void* dest, const void* src, int stop, size_t nbytes)
 {
-    for (int i = 0; i < nbytes; ++i) {
+    for (int i = 0; i < nbytes; i++) {
         *((uint8_t*)dest + i) = *((uint8_t*)src + i);
-        if (*((uint8_t*)src + i) == stop) {
+
+        if (*((uint8_t*)src + i) == stop)
             return ((uint8_t*)dest + i + 1);
-        }
     }
     return NULL;
 }
 
 int memcmp(const void* src1, const void* src2, size_t nbytes)
 {
-    for (int i = 0; i < nbytes; ++i) {
-        if (*((uint8_t*)src1 + i) < *((uint8_t*)src2 + i)) {
-            return -1;
-        }
-        if (*((uint8_t*)src1 + i) > *((uint8_t*)src2 + i)) {
-            return 1;
-        }
+    uint8_t *first, *second;
+
+    for (int i = 0; i < nbytes; i++) {
+        first = (uint8_t*)src1 + i;
+        second = (uint8_t*)src2 + i;
+
+        if (*first < *second)
+            return first - second;
+
+        if (*first > *second)
+            return first - second;
     }
+
     return 0;
 }
 
@@ -100,9 +106,9 @@ size_t strlen(const char* str)
 char* strcpy(char* dest, const char* src)
 {
     size_t i;
-    for (i = 0; src[i] != 0; i++) {
+    for (i = 0; src[i] != 0; i++)
         dest[i] = src[i];
-    }
+
     dest[i] = '\0';
     return dest;
 }


### PR DESCRIPTION
The `memcpy` function now copies over 4 bytes at a time (one register on 32 bits), making the function a lot faster for larger amounts of data. Of course, copying over 3 bytes does not yield any speed upgrade.